### PR TITLE
Update readme path for js docs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "out": "docs",
     "excludeExternals": true,
     "name": "Subsocial JS SDK",
+    "readme": "./README.md",
     "customCss": "./themes/main.css",
     "hideGenerator": true,
   }


### PR DESCRIPTION
Modify readme path so that the description in js docs refers to `./README.md` (with the final version in #116)