### PR TITLE
Change Twitter Parser to use Autolinker

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@polkadot/util-crypto": "latest",
     "@sindresorhus/slugify": "^1.1.0",
+    "autolinker": "^4.0.0",
     "bignumber.js": "^9.0.1",
     "bn.js": "^5.1.1",
     "chalk": "^3.0.0",

--- a/packages/utils/src/test/twitter/twitter-utils.test.ts
+++ b/packages/utils/src/test/twitter/twitter-utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "@jest/globals"
-import { twitterParser } from '../../twitter'
+import { describe, expect, test } from '@jest/globals'
+import { parseTwitterTextToMarkdown } from '../../twitter'
 
 const mocks = {
   longTweet: `Super GM #Dotsama 
@@ -19,77 +19,134 @@ const mocks = {
     
     🥂🚀`,
   inputHashtag: `Polkadot is the new #Web3 ecosystem.`,
-  outputHashtag: `Polkadot is the new [#Web3](https://twitter.com/hashtag/Web3?src=hashtag_click) ecosystem.`,
-  inputHashtagDigitOnly: "First thing #1, second thing #2, third thing #3",
-  inputNoWhiteSpace: "123#sofun",
-  inputHashtagWithPunctuation: "#it’sfun",
-  outputHashtagWithPunctuation: "#it",
-  inputUsername: "@SubsocialChain is a decentralised social finance platform.",
+  outputHashtag: `Polkadot is the new [#Web3](https://twitter.com/hashtag/Web3) ecosystem.`,
+  inputNoWhiteSpace: '123#sofun test#Subsocial',
+  inputJustHashtag: '#Subsocial',
+  outputJustHashtag: '[#Subsocial](https://twitter.com/hashtag/Subsocial)',
+  inputHashtagInFirstLetter: '#Subsocial is a blockchain',
+  outputHashtagInFirstLetter: '[#Subsocial](https://twitter.com/hashtag/Subsocial) is a blockchain',
+  inputHashtagWithPunctuation: '#it’sfun',
+  outputHashtagWithPunctuation: '#it',
+  inputUsername: '@SubsocialChain is a decentralised social finance platform.',
   outputUsername:
-    "[@SubsocialChain](https://twitter.com/SubsocialChain) is a decentralised social finance platform.",
-  inputUsernameWithCharPrefix: "123@TwitterSupport",
+    '[@SubsocialChain](https://twitter.com/SubsocialChain) is a decentralised social finance platform.',
+  inputUsernameWithCharPrefix: '123@TwitterSupport',
+  inputLink: 'Polkaverse link https://polkaverse.com',
+  outputLink: 'Polkaverse link [https://polkaverse.com](https://polkaverse.com)',
+  inputMultipleLink:
+    'Polkaverse https://polkaverse.com and google here https://google.com',
+  outputMultipleLink:
+    'Polkaverse [https://polkaverse.com](https://polkaverse.com) and google here [https://google.com](https://google.com)',
+  inputAllFormat:
+    'Polkaverse tag #Polkaverse with link https://polkaverse.com#test to @SubsocialChain with link https://polkaverse.com#test@subsocial and https://google.com . and link https://polkaverse.com.@SubsocialChain https://polkaverse.com.#test',
+  outputAllFormat:
+    'Polkaverse tag [#Polkaverse](https://twitter.com/hashtag/Polkaverse) with link [https://polkaverse.com#test](https://polkaverse.com#test) to [@SubsocialChain](https://twitter.com/SubsocialChain) with link [https://polkaverse.com#test@subsocial](https://polkaverse.com#test@subsocial) and [https://google.com](https://google.com) . and link [https://polkaverse.com](https://polkaverse.com).@SubsocialChain [https://polkaverse.com](https://polkaverse.com).#test',
 }
 
-describe("Hashtag parser", () => {
-  test("should return a defined value when given a non-empty string", () => {
-    expect(twitterParser.parseHashtags(mocks.longTweet)).toBeDefined()
+describe('Hashtag parser', () => {
+  test('should return a defined value when given a non-empty string', () => {
+    expect(parseTwitterTextToMarkdown(mocks.longTweet)).toBeDefined()
   })
 
-  test("should return a string when given a non-empty string", () => {
-    expect(typeof twitterParser.parseHashtags(mocks.longTweet)).toBe("string")
+  test('should return a string when given a non-empty string', () => {
+    expect(typeof parseTwitterTextToMarkdown(mocks.longTweet)).toBe('string')
   })
 
-  test("should return markdown-formatted string when given a string with hashtag", () => {
-    expect(twitterParser.parseHashtags(mocks.inputHashtag)).toMatch(mocks.outputHashtag)
-  })
-
-  test("should not parse the hashtag if it is followed by digits only", () => {
-    expect(twitterParser.parseHashtags(mocks.inputHashtagDigitOnly)).toMatch(mocks.inputHashtagDigitOnly)
-  })
-
-  test("should not work for letters or numbers in front of the # symbol", () => {
-    expect(twitterParser.parseHashtags(mocks.inputNoWhiteSpace)).toMatch(mocks.inputNoWhiteSpace)
-  })
-
-  test("should cut words in hashtag if punctuation is present", () => {
-    expect(twitterParser.parseHashtags(mocks.inputHashtagWithPunctuation)).toMatch(
-      mocks.outputHashtagWithPunctuation,
+  test('should return markdown-formatted string when given a string with hashtag', () => {
+    expect(parseTwitterTextToMarkdown(mocks.inputHashtag)).toMatch(
+      mocks.outputHashtag
     )
+  })
+
+  test('should work for text with just hashtag', () => {
+    expect(parseTwitterTextToMarkdown(mocks.inputJustHashtag)).toMatch(
+      mocks.outputJustHashtag
+    )
+  })
+
+  test('should work for text that begins with hashtag', () => {
+    expect(parseTwitterTextToMarkdown(mocks.inputHashtagInFirstLetter)).toMatch(
+      mocks.outputHashtagInFirstLetter
+    )
+  })
+
+  test('should not work for letters or numbers in front of the # symbol', () => {
+    expect(parseTwitterTextToMarkdown(mocks.inputNoWhiteSpace)).toMatch(
+      mocks.inputNoWhiteSpace
+    )
+  })
+
+  test('should cut words in hashtag if punctuation is present', () => {
+    expect(
+      parseTwitterTextToMarkdown(mocks.inputHashtagWithPunctuation)
+    ).toMatch(mocks.outputHashtagWithPunctuation)
   })
 })
 
-describe("Username parser", () => {
-  test("should return a defined value when given a non-empty string", () => {
-    expect(twitterParser.parseUsernames(mocks.longTweet)).toBeDefined()
+describe('Username parser', () => {
+  test('should return a defined value when given a non-empty string', () => {
+    expect(parseTwitterTextToMarkdown(mocks.longTweet)).toBeDefined()
   })
 
-  test("should return a string when given a non-empty string", () => {
-    expect(typeof twitterParser.parseUsernames(mocks.longTweet)).toBe("string")
+  test('should return a string when given a non-empty string', () => {
+    expect(typeof parseTwitterTextToMarkdown(mocks.longTweet)).toBe('string')
   })
 
-  test("should return markdown-formatted string when given a string with @ symbol", () => {
-    expect(twitterParser.parseUsernames(mocks.inputUsername)).toMatch(mocks.outputUsername)
-  })
-
-  test("should return the same string if usernames preceeded with characters", () => {
-    expect(twitterParser.parseUsernames(mocks.inputUsernameWithCharPrefix)).toMatch(
-      mocks.inputUsernameWithCharPrefix,
+  test('should return markdown-formatted string when given a string with @ symbol', () => {
+    expect(parseTwitterTextToMarkdown(mocks.inputUsername)).toMatch(
+      mocks.outputUsername
     )
+  })
+
+  test('should return the same string if usernames preceeded with characters', () => {
+    expect(
+      parseTwitterTextToMarkdown(mocks.inputUsernameWithCharPrefix)
+    ).toMatch(mocks.inputUsernameWithCharPrefix)
   })
 })
 
-describe("Markdown parser", () => {
-  test("should return a defined value when given a non-empty string", () => {
-    expect(twitterParser.parseTextToMarkdown(mocks.longTweet)).toBeDefined()
+describe('Link Parser', () => {
+  test('should return markdown-formatted links', () => {
+    expect(
+      parseTwitterTextToMarkdown(
+        mocks.inputLink
+      )
+    ).toMatch(mocks.outputLink)
   })
 
-  test("should return a string when given a non-empty string", () => {
-    expect(typeof twitterParser.parseTextToMarkdown(mocks.longTweet)).toBe("string")
+  test('should be able to parse multiple links', () => {
+    expect(
+      parseTwitterTextToMarkdown(
+        mocks.inputMultipleLink
+      )
+    ).toMatch(mocks.outputMultipleLink)
+  })
+})
+
+describe('All Format Parser', () => {
+  test('should return a defined value when given a non-empty string', () => {
+    expect(parseTwitterTextToMarkdown(mocks.longTweet)).toBeDefined()
   })
 
-  test("should return markdown-formatted strings for usernames and hashtags", () => {
-    expect(twitterParser.parseTextToMarkdown(mocks.inputHashtag + mocks.inputUsername)).toMatch(
-      mocks.outputHashtag + mocks.outputUsername,
+  test('should return a string when given a non-empty string', () => {
+    expect(typeof parseTwitterTextToMarkdown(mocks.longTweet)).toBe(
+      'string'
     )
+  })
+
+  test('should return markdown-formatted strings for usernames and hashtags', () => {
+    expect(
+      parseTwitterTextToMarkdown(
+        mocks.inputHashtag + ' ' + mocks.inputUsername
+      )
+    ).toMatch(mocks.outputHashtag + ' ' +  mocks.outputUsername)
+  })
+
+  test('should return markdown-formatted strings for usernames and hashtags and links', () => {
+    expect(
+      parseTwitterTextToMarkdown(
+        mocks.inputAllFormat
+      )
+    ).toMatch(mocks.outputAllFormat)
   })
 })

--- a/packages/utils/src/test/twitter/twitter-utils.test.ts
+++ b/packages/utils/src/test/twitter/twitter-utils.test.ts
@@ -31,8 +31,8 @@ const mocks = {
   outputUsername:
     '[@SubsocialChain](https://twitter.com/SubsocialChain) is a decentralised social finance platform.',
   inputUsernameWithCharPrefix: '123@TwitterSupport',
-  inputLink: 'Polkaverse link https://polkaverse.com',
-  outputLink: 'Polkaverse link [https://polkaverse.com](https://polkaverse.com)',
+  inputLink: 'Polkaverse link https://polkaverse.com google.com',
+  outputLink: 'Polkaverse link [https://polkaverse.com](https://polkaverse.com) [google.com](http://google.com)',
   inputMultipleLink:
     'Polkaverse https://polkaverse.com and google here https://google.com',
   outputMultipleLink:

--- a/packages/utils/src/test/twitter/twitter-utils.test.ts
+++ b/packages/utils/src/test/twitter/twitter-utils.test.ts
@@ -37,6 +37,9 @@ const mocks = {
     'Polkaverse https://polkaverse.com and google here https://google.com',
   outputMultipleLink:
     'Polkaverse [https://polkaverse.com](https://polkaverse.com) and google here [https://google.com](https://google.com)',
+  inputWithEmailAndPhone: '082342342341234 test@test.com should not be parsed',
+  inputWithHtml: '<script>let a = 0; alert("test")</script> is a script that should be <sanitized',
+  outputWithHtml: '&lt;script&gt;let a = 0; alert("test")&lt;/script&gt; is a script that should be &lt;sanitized',
   inputAllFormat:
     'Polkaverse tag #Polkaverse with link https://polkaverse.com#test to @SubsocialChain with link https://polkaverse.com#test@subsocial and https://google.com . and link https://polkaverse.com.@SubsocialChain https://polkaverse.com.#test',
   outputAllFormat:
@@ -132,6 +135,14 @@ describe('All Format Parser', () => {
     expect(typeof parseTwitterTextToMarkdown(mocks.longTweet)).toBe(
       'string'
     )
+  })
+
+  test('should not parse email and phone number', () => {
+    expect(parseTwitterTextToMarkdown(mocks.inputWithEmailAndPhone)).toMatch(mocks.inputWithEmailAndPhone)
+  })
+
+  test('should sanitize html', () => {
+    expect(parseTwitterTextToMarkdown(mocks.inputWithHtml)).toMatch(mocks.outputWithHtml)
   })
 
   test('should return markdown-formatted strings for usernames and hashtags', () => {

--- a/packages/utils/src/test/twitter/twitter-utils.test.ts
+++ b/packages/utils/src/test/twitter/twitter-utils.test.ts
@@ -33,10 +33,6 @@ const mocks = {
   inputUsernameWithCharPrefix: '123@TwitterSupport',
   inputLink: 'Polkaverse link https://polkaverse.com google.com',
   outputLink: 'Polkaverse link [https://polkaverse.com](https://polkaverse.com) [google.com](http://google.com)',
-  inputMultipleLink:
-    'Polkaverse https://polkaverse.com and google here https://google.com',
-  outputMultipleLink:
-    'Polkaverse [https://polkaverse.com](https://polkaverse.com) and google here [https://google.com](https://google.com)',
   inputWithEmailAndPhone: '082342342341234 test@test.com should not be parsed',
   inputWithHtml: '<script>let a = 0; alert("test")</script> is a script that should be <sanitized',
   outputWithHtml: '&lt;script&gt;let a = 0; alert("test")&lt;/script&gt; is a script that should be &lt;sanitized',
@@ -115,14 +111,6 @@ describe('Link Parser', () => {
         mocks.inputLink
       )
     ).toMatch(mocks.outputLink)
-  })
-
-  test('should be able to parse multiple links', () => {
-    expect(
-      parseTwitterTextToMarkdown(
-        mocks.inputMultipleLink
-      )
-    ).toMatch(mocks.outputMultipleLink)
   })
 })
 

--- a/packages/utils/src/twitter.ts
+++ b/packages/utils/src/twitter.ts
@@ -1,44 +1,22 @@
 import { TweetPostContent } from './types/twitter'
+import Autolinker from 'autolinker'
 
 const BASE_TWITTER_URL = 'https://twitter.com'
 
-const parseHashtags = (text: string) => {
-  const result = text.replace(
-    /(\s#)(\w+[a-zA-Z0-9]+)/g,
-    ` [#$2](${BASE_TWITTER_URL}/hashtag/$2?src=hashtag_click)`
-  )
+export const parseTwitterTextToMarkdown = (text: string) => {
+  const parsed = Autolinker.link(text, {
+    mention: 'twitter',
+    hashtag: 'twitter',
+    stripPrefix: false,
+    replaceFn: function (match) {
+      const href = match.getAnchorHref()
+      const text = match.getAnchorText()
 
-  return result
-}
+      return `[${text}](${href})`
+    },
+  })
 
-const parseUsernames = (text: string) => {
-  const result = text.replace(
-    /(?<!\w)@([a-zA-Z0-9_]+){1,15}/g,
-    `[@$1](${BASE_TWITTER_URL}/$1)`
-  )
-
-  return result
-}
-
-const parseLinks = (text: string) => {
-  const urlRegex =
-      /\b(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))\b/g
-  return text.replace(urlRegex, '<$1>')
-}
-
-const parseTextToMarkdown = (text: string) => {
-  const linksParsed = parseLinks(text)
-  const linksAndHashtagsParsed = parseHashtags(linksParsed)
-  const markdown = parseUsernames(linksAndHashtagsParsed)
-
-  return markdown
-}
-
-export const twitterParser = {
-  parseLinks,
-  parseHashtags,
-  parseUsernames,
-  parseTextToMarkdown,
+  return parsed
 }
 
 export const createTwitterURL = (tweet: TweetPostContent) => {

--- a/packages/utils/src/twitter.ts
+++ b/packages/utils/src/twitter.ts
@@ -1,6 +1,6 @@
 import { TweetPostContent } from './types/twitter'
 
-const BASE_TWITTER_URL = "https://twitter.com"
+const BASE_TWITTER_URL = 'https://twitter.com'
 
 const parseHashtags = (text: string) => {
   const result = text.replace(
@@ -42,5 +42,5 @@ export const twitterParser = {
 }
 
 export const createTwitterURL = (tweet: TweetPostContent) => {
-    return `${BASE_TWITTER_URL}/${tweet.username}/status/${tweet.id}`
+  return `${BASE_TWITTER_URL}/${tweet.username}/status/${tweet.id}`
 }

--- a/packages/utils/src/twitter.ts
+++ b/packages/utils/src/twitter.ts
@@ -8,6 +8,9 @@ export const parseTwitterTextToMarkdown = (text: string) => {
     mention: 'twitter',
     hashtag: 'twitter',
     stripPrefix: false,
+    phone: false,
+    email: false,
+    sanitizeHtml: true,
     replaceFn: function (match) {
       const href = match.getAnchorHref()
       const text = match.getAnchorText()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2458,6 +2458,13 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+autolinker@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-4.0.0.tgz#aa1f9a52786b727b0ecee8cd7d4a97e0e3ef59f1"
+  integrity sha512-fl5Kh6BmEEZx+IWBfEirnRUU5+cOiV0OK7PEt0RBKvJMJ8GaRseIOeDU3FKf4j3CE5HVefcjHmhYPOcaVt0bZw==
+  dependencies:
+    tslib "^2.3.0"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -8737,6 +8744,11 @@ tslib@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
By using [Autolinker](https://www.npmjs.com/package/autolinker), we can handle most cases, especially for URLs, it will be most likely better than using our own regex that we have to maintain.

Autolinker package itself is about 18kb (gzipped)
![image](https://user-images.githubusercontent.com/53143942/216604387-cb92d4a9-6933-417e-a457-87985a68232f.png)

Autolinker feature:
- Can parse links without http/https prefix
- Sanitize HTML

I have tried to do this by using own regex, if the link parser is used by itself, but it needs to be done first before the other parser, making parsing like `https://polkaverse.com/@subsocial` needs more conditions, so `@subsocial` in the link didn't get parsed.
To fix the case above, its actually not that hard, but I think it's hard to check each case and handle most of them.

## Drawbacks
But there are some things that were tested and succeed in previous version, but fails after I change to autolinker (so I remove the corresponding tests):
- it still resolves link that is concatenated with string. e.g. `testhttps://google.com` it still resolves the `https://google.com` as link
- it resolves hashtag with number in the first letter. e.g. `#1 #2`. But I think it's still ok because the link still can be visited.